### PR TITLE
Add support for getting details from ha.io/version.json

### DIFF
--- a/pyhaversion/consts.py
+++ b/pyhaversion/consts.py
@@ -43,4 +43,5 @@ URL = {
         "beta": "https://version.home-assistant.io/beta.json",
     },
     "pypi": "https://pypi.org/pypi/homeassistant/json",
+    "haio": "https://www.home-assistant.io/version.json",
 }


### PR DESCRIPTION
Reading the details from https://www.home-assistant.io/version.json. Obviously, only support for other `stable`.