### PR TITLE
Fix get hassos-cli key

### DIFF
--- a/pyhaversion/__init__.py
+++ b/pyhaversion/__init__.py
@@ -167,9 +167,9 @@ class HassioVersion(Version):
 
                 self._version = data["homeassistant"][IMAGES[self.image]["hassio"]]
 
-                self._version_data["hassos"] = data["hassos"][board]
-                self._version_data["supervisor"] = data["supervisor"]
-                self._version_data["hassos-cli"] = data["hassos-cli"]
+                self._version_data["hassos"] = data.get("hassos", {}).get(board)
+                self._version_data["supervisor"] = data.get("supervisor")
+                self._version_data["cli"] = data.get("cli")
 
             _LOGGER.debug("Version: %s", self.version)
             _LOGGER.debug("Version data: %s", self.version_data)

--- a/tests/fixtures/fixture_hassio.py
+++ b/tests/fixtures/fixture_hassio.py
@@ -9,7 +9,7 @@ def hassio_response():
         "supervisor": "999",
         "homeassistant": {"default": "9.99.9"},
         "hassos": {"ova": "9.99"},
-        "hassos-cli": "9",
+        "cli": "9",
     }
 
 
@@ -20,7 +20,7 @@ def hassio_beta_response():
         "supervisor": "999",
         "homeassistant": {"default": "9.99.9"},
         "hassos": {"ova": "9.99"},
-        "hassos-cli": "9",
+        "cli": "9",
     }
 
 
@@ -31,7 +31,7 @@ def hassio_response_beta_week():
         "supervisor": "999",
         "homeassistant": {"default": "9.98.9"},
         "hassos": {"ova": "9.99"},
-        "hassos-cli": "9",
+        "cli": "9",
     }
 
 
@@ -42,5 +42,5 @@ def hassio_beta_response_beta_week():
         "supervisor": "999",
         "homeassistant": {"default": "9.99.9b0"},
         "hassos": {"ova": "9.99"},
-        "hassos-cli": "9",
+        "cli": "9",
     }


### PR DESCRIPTION
The `hassos-cli` is no longer used, and now removed from the version file.

Causing:
![image](https://user-images.githubusercontent.com/195327/93013093-8ea7ec00-f5a5-11ea-8ea3-54f6debd5884.png)

I've adjusted the key to `cli`, which is the one to use.

Furthermore, changed all data extractions to use `.get()` to prevent similar issues whenever the data format changes.
